### PR TITLE
解决windows下调整音量时controller会隐藏

### DIFF
--- a/lib/modules/live_play/widgets/video_player/volume_control.dart
+++ b/lib/modules/live_play/widgets/video_player/volume_control.dart
@@ -108,9 +108,13 @@ class _OverlayVolumeControlState extends State<OverlayVolumeControl> {
           targetAnchor: Alignment.topCenter,
           offset: const Offset(0, 5),
           child: MouseRegion(
-            onEnter: (_) => _isMouseInBar = true,
+            onEnter: (_) {
+              _isMouseInBar = true;
+              controller.stopHideController();
+            },
             onExit: (_) {
               _isMouseInBar = false;
+              controller.enableController();
               _startHideTimer();
             },
             child: _buildVolumeBarUI(),


### PR DESCRIPTION
# 问题
windows下正在调整音量时controller会隐藏导致音量栏出现位移