### PR TITLE
fix(macos): disable MediaKit hardware acceleration on startup

### DIFF
--- a/lib/player/adapters/media_kit_adapter.dart
+++ b/lib/player/adapters/media_kit_adapter.dart
@@ -101,6 +101,10 @@ class MediaKitAdapter implements UnifiedPlayer {
 
           await native.setProperty('http-proxy', proxyUrl);
         }
+
+        if (PlatformUtils.isMacOS) {
+          await native.setProperty('hwdec', 'no');
+        }
       }
 
       // =========================
@@ -126,13 +130,15 @@ class MediaKitAdapter implements UnifiedPlayer {
               _player,
               configuration: VideoControllerConfiguration(
                 vo: SettingsService.to.player.videoOutputDriver.v,
-                hwdec: SettingsService.to.player.videoHardwareDecoder.v,
+                hwdec: PlatformUtils.isMacOS ? 'no' : SettingsService.to.player.videoHardwareDecoder.v,
+                enableHardwareAcceleration: !PlatformUtils.isMacOS,
               ),
             )
           : VideoController(
               _player,
               configuration: VideoControllerConfiguration(
-                enableHardwareAcceleration: SettingsService.to.player.enableCodec.v,
+                enableHardwareAcceleration: PlatformUtils.isMacOS ? false : SettingsService.to.player.enableCodec.v,
+                hwdec: PlatformUtils.isMacOS ? 'no' : null,
                 androidAttachSurfaceAfterVideoParameters: false,
               ),
             );


### PR DESCRIPTION
Fixes #685

## What broke

On macOS, the app pre-warms MediaKit at startup. With `enableHardwareAcceleration: true` (default), MPV tries to init hardware textures and crashes in ~0.6s.

Crash stack (v2.0.21, macOS 26.5, Apple Silicon):

```
VideoOutput._init()
  → TextureHW.initMPV()
  → mpv_render_context_create()
  → TextureHW.getProcAddress()  // SIGSEGV
```

Reproducible on 2.0.21 / 2.0.22.

## Fix

[`lib/player/adapters/media_kit_adapter.dart`](lib/player/adapters/media_kit_adapter.dart) only:

- macOS: `enableHardwareAcceleration: false`
- macOS: `hwdec: 'no'` (VideoController + NativePlayer)

## Trade-off

macOS uses **software decode** for now. Playback works; CPU use may be **higher** than HW decode. Other platforms unchanged.

Re-enabling HW accel later is a small revert here, but probably needs media_kit/mpv to fix `TextureHW` on recent macOS first.

## Tested

macOS 26.5 · Apple Silicon · Xcode 26.5 · Flutter 3.44.1

- Launch: OK (no instant crash)
- Live room playback: OK

<img width="1279" height="717" alt="Snipaste_2026-06-07_21-19-19" src="https://github.com/user-attachments/assets/f6de5397-1db8-4b89-a539-c0909a63b645" />
<img width="1275" height="715" alt="Snipaste_2026-06-07_21-36-40" src="https://github.com/user-attachments/assets/9c7e0bda-7945-4171-a3db-388e369c6395" />