### PR TITLE
fix(macos): restore trackpad scrolling on desktop

### DIFF
--- a/lib/common/global/platform/desktop_manager.dart
+++ b/lib/common/global/platform/desktop_manager.dart
@@ -738,8 +738,10 @@ class MyCustomScrollBehavior extends MaterialScrollBehavior {
   @override
   Set<PointerDeviceKind> get dragDevices => {
     PointerDeviceKind.touch,
-    PointerDeviceKind.mouse,
     PointerDeviceKind.stylus,
+    PointerDeviceKind.invertedStylus,
+    PointerDeviceKind.trackpad,
     PointerDeviceKind.unknown,
+    PointerDeviceKind.mouse,
   };
 }

--- a/lib/player/adapters/media_kit_adapter.dart
+++ b/lib/player/adapters/media_kit_adapter.dart
@@ -101,6 +101,10 @@ class MediaKitAdapter implements UnifiedPlayer {
 
           await native.setProperty('http-proxy', proxyUrl);
         }
+
+        if (PlatformUtils.isMacOS) {
+          await native.setProperty('hwdec', 'no');
+        }
       }
 
       // =========================
@@ -126,13 +130,15 @@ class MediaKitAdapter implements UnifiedPlayer {
               _player,
               configuration: VideoControllerConfiguration(
                 vo: SettingsService.to.player.videoOutputDriver.v,
-                hwdec: SettingsService.to.player.videoHardwareDecoder.v,
+                hwdec: PlatformUtils.isMacOS ? 'no' : SettingsService.to.player.videoHardwareDecoder.v,
+                enableHardwareAcceleration: !PlatformUtils.isMacOS,
               ),
             )
           : VideoController(
               _player,
               configuration: VideoControllerConfiguration(
-                enableHardwareAcceleration: SettingsService.to.player.enableCodec.v,
+                enableHardwareAcceleration: PlatformUtils.isMacOS ? false : SettingsService.to.player.enableCodec.v,
+                hwdec: PlatformUtils.isMacOS ? 'no' : null,
                 androidAttachSurfaceAfterVideoParameters: false,
               ),
             );

--- a/test/desktop_scroll_behavior_test.dart
+++ b/test/desktop_scroll_behavior_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pure_live/common/global/platform/desktop_manager.dart';
+
+void main() {
+  test('MyCustomScrollBehavior supports trackpad and mouse drag scrolling', () {
+    final behavior = MyCustomScrollBehavior();
+
+    expect(behavior.dragDevices, contains(PointerDeviceKind.trackpad));
+    expect(behavior.dragDevices, contains(PointerDeviceKind.invertedStylus));
+    expect(behavior.dragDevices, contains(PointerDeviceKind.mouse));
+    expect(behavior.dragDevices, contains(PointerDeviceKind.touch));
+  });
+}


### PR DESCRIPTION
## Summary
- Restore `PointerDeviceKind.trackpad` and `invertedStylus` in `MyCustomScrollBehavior.dragDevices`
- Keeps `mouse` for desktop drag-to-scroll; mouse wheel unchanged
- Add unit test to lock drag device set

Fixes #585

## Depends on
- #714 should merge first; then rebase this branch onto `master`

## Test plan
- [x] macOS 26.5: trackpad two-finger scroll on Settings / list pages
- [x] Mouse wheel still works
- [x] `flutter test test/desktop_scroll_behavior_test.dart`