### PR TITLE
fix: harden local Java detection and APK download variants

### DIFF
--- a/.github/workflows/local-signed-android.yml
+++ b/.github/workflows/local-signed-android.yml
@@ -21,18 +21,34 @@ jobs:
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Select cached local Java 25
+      - name: Select local Java 25
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $jdk = Get-ChildItem (Join-Path $env:RUNNER_TOOL_CACHE 'Java_Zulu_jdk\25*\x64') `
-            -Directory -ErrorAction SilentlyContinue |
-            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName 'bin\java.exe') } |
-            Sort-Object FullName -Descending |
-            Select-Object -First 1 -ExpandProperty FullName
-          if (-not $jdk) {
-            throw 'Cached Java 25 was not found on the local runner.'
+          $candidates = @()
+          if ($env:RUNNER_TOOL_CACHE) {
+            $candidates += Get-ChildItem (Join-Path $env:RUNNER_TOOL_CACHE 'Java_Zulu_jdk\25*\x64') `
+              -Directory -ErrorAction SilentlyContinue |
+              Sort-Object FullName -Descending |
+              Select-Object -ExpandProperty FullName
           }
+          $candidates += @(
+            'C:\Program Files\Android\Android Studio\jbr',
+            $env:JAVA_HOME
+          ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+          $jdk = $candidates |
+            Where-Object {
+              $java = Join-Path $_ 'bin\java.exe'
+              if (-not (Test-Path -LiteralPath $java -PathType Leaf)) { return $false }
+              $versionText = (& $java -version 2>&1 | Out-String)
+              return $versionText -match 'version\s+"25(?:\.|\")'
+            } |
+            Select-Object -First 1
+          if (-not $jdk) {
+            throw 'Java 25 was not found in the runner cache, Android Studio JBR, or JAVA_HOME.'
+          }
+          $jdk = (Resolve-Path -LiteralPath $jdk).Path
           "JAVA_HOME=$jdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           (Join-Path $jdk 'bin') | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & (Join-Path $jdk 'bin\java.exe') -version

--- a/assets/version.json
+++ b/assets/version.json
@@ -2,6 +2,11 @@
   "version": "2.1.4",
   "build_number": 52,
   "version_num": 2010452,
+  "android_abis": [
+    "armeabi-v7a",
+    "arm64-v8a",
+    "x86_64"
+  ],
   "version_desc": "v2.1.4 阶段性全平台更新\n- Bilibili 热门迁移到当前匿名推荐接口，增加回退、结构校验和封面缓存修复。\n- Windows 动态识别窗口所在显示器当前及最高刷新率，优化滚动、转场、缓存和重复监听。\n- 同步上游 5d3e526a，兼容 sooplive.com / sooplive.co.kr 与当前 SOOP 播放链路。\n- 补齐 Android arm64、Windows x64、Linux x64、macOS universal 和 iOS arm64 设备归档。\n",
   "prerelease": false,
   "download_url": "https://github.com/liuchuancong/pure_live/releases",

--- a/lib/common/utils/version_util.dart
+++ b/lib/common/utils/version_util.dart
@@ -10,11 +10,13 @@ class VersionUtil {
   static PackageInfo? _packageInfo;
 
   static const String projectUrl = 'https://github.com/liuchuancong/pure_live';
-  static const String issuesUrl = 'https://github.com/liuchuancong/pure_live/issues';
+  static const String issuesUrl =
+      'https://github.com/liuchuancong/pure_live/issues';
   static const String githubUrl = 'https://github.com/liuchuancong';
 
   static const String email = '17792321552@163.com';
-  static const String emailUrl = 'mailto:17792321552@163.com?subject=PureLive Feedback';
+  static const String emailUrl =
+      'mailto:17792321552@163.com?subject=PureLive Feedback';
 
   static const String telegramGroup = 't.me/pure_live_channel';
   static const String telegramGroupUrl = 'https://t.me/pure_live_channel';
@@ -22,9 +24,14 @@ class VersionUtil {
   static const String kanbanUrl =
       'https://jackiu-notes.notion.site/50bc0d3d377445eea029c6e3d4195671?v=663125e639b047cea5e69d8264926b8b';
 
-  static const String releaseUrl = 'https://api.github.com/repos/liuchuancong/pure_live/releases?per_page=30';
+  static const String releaseUrl =
+      'https://api.github.com/repos/liuchuancong/pure_live/releases?per_page=30';
 
-  static final GitHubMirror mirror = GitHubMirror(owner: 'liuchuancong', repo: 'pure_live', branch: 'master');
+  static final GitHubMirror mirror = GitHubMirror(
+    owner: 'liuchuancong',
+    repo: 'pure_live',
+    branch: 'master',
+  );
 
   static List<String> get _versionUrls => mirror.mirrors('assets/version.json');
 
@@ -36,6 +43,7 @@ class VersionUtil {
   static String latestUpdateLog = '';
   static bool prerelease = false;
   static String downloadUrl = '';
+  static Set<String> latestAndroidAbis = const {'arm64-v8a'};
   var allReleased = [].obs;
 
   static Map<String, dynamic>? _cachedVersionJson;
@@ -93,19 +101,35 @@ class VersionUtil {
   }
 
   static void _applyVersionData(Map<String, dynamic> data) {
-    final selected = selectPlatformVersionData(data, platform: _currentPlatformKey);
+    final selected = selectPlatformVersionData(
+      data,
+      platform: _currentPlatformKey,
+    );
     latestVersion = selected['version']?.toString() ?? version;
     latestVersionNum = selected['version_num'] ?? 0;
     latestBuildNumber = selected['build_number'];
     latestUpdateLog = selected['version_desc']?.toString() ?? '';
     prerelease = selected['prerelease'] == true;
     downloadUrl = selected['download_url']?.toString() ?? '';
+    latestAndroidAbis = selectAndroidAbis(selected);
+  }
+
+  /// Keeps download buttons aligned with the APK variants that the current
+  /// release feed explicitly declares. Older feeds keep the arm64 default.
+  static Set<String> selectAndroidAbis(Map<String, dynamic> data) {
+    const supported = {'armeabi-v7a', 'arm64-v8a', 'x86_64'};
+    final raw = data['android_abis'];
+    if (raw is! List) return const {'arm64-v8a'};
+    return raw.map((item) => item.toString()).where(supported.contains).toSet();
   }
 
   /// Keeps update announcements aligned with the artifacts that were really
   /// published for each platform. The top-level object remains the fallback
   /// for older feeds and older clients.
-  static Map<String, dynamic> selectPlatformVersionData(Map<String, dynamic> data, {required String platform}) {
+  static Map<String, dynamic> selectPlatformVersionData(
+    Map<String, dynamic> data, {
+    required String platform,
+  }) {
     final platforms = data['platforms'];
     final platformData = platforms is Map ? platforms[platform] : null;
     if (platformData is! Map) return data;
@@ -123,13 +147,18 @@ class VersionUtil {
 
   static bool hasNewVersion() {
     try {
-      final latestClean = latestVersion.split('-')[0].replaceAll('v', '').trim();
+      final latestClean = latestVersion
+          .split('-')[0]
+          .replaceAll('v', '')
+          .trim();
       final currentClean = version.split('-')[0].replaceAll('v', '').trim();
 
       final latestParts = latestClean.split('.').map(int.parse).toList();
       final currentParts = currentClean.split('.').map(int.parse).toList();
 
-      final maxLength = latestParts.length > currentParts.length ? latestParts.length : currentParts.length;
+      final maxLength = latestParts.length > currentParts.length
+          ? latestParts.length
+          : currentParts.length;
 
       while (latestParts.length < maxLength) {
         latestParts.add(0);

--- a/lib/modules/version/version_controller.dart
+++ b/lib/modules/version/version_controller.dart
@@ -2,19 +2,29 @@ import 'package:pure_live/common/index.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 class ReleaseAssetUrls {
-  const ReleaseAssetUrls({required this.projectUrl, required this.version, required this.buildNumber});
+  const ReleaseAssetUrls({
+    required this.projectUrl,
+    required this.version,
+    required this.buildNumber,
+  });
 
   final String projectUrl;
   final String version;
   final int buildNumber;
 
   String get releaseBase => '$projectUrl/releases/download/v$version';
-  String get androidArm64 => '$releaseBase/PureLive-$version-$buildNumber-arm64-v8a-release.apk';
-  String get androidArmeabiV7a => '$releaseBase/PureLive-$version-$buildNumber-armeabi-v7a-release.apk';
-  String get androidX8664 => '$releaseBase/PureLive-$version-$buildNumber-x86_64-release.apk';
-  String get windowsSetup => '$releaseBase/PureLive-$version-windows-x64-setup.exe';
-  String get windowsPortable => '$releaseBase/PureLive-$version-$buildNumber-windows-x64-portable.zip';
-  String get macosUniversal => '$releaseBase/PureLive-$version-$buildNumber-macos-universal.zip';
+  String get androidArm64 =>
+      '$releaseBase/PureLive-$version-$buildNumber-arm64-v8a-release.apk';
+  String get androidArmeabiV7a =>
+      '$releaseBase/PureLive-$version-$buildNumber-armeabi-v7a-release.apk';
+  String get androidX8664 =>
+      '$releaseBase/PureLive-$version-$buildNumber-x86_64-release.apk';
+  String get windowsSetup =>
+      '$releaseBase/PureLive-$version-windows-x64-setup.exe';
+  String get windowsPortable =>
+      '$releaseBase/PureLive-$version-$buildNumber-windows-x64-portable.zip';
+  String get macosUniversal =>
+      '$releaseBase/PureLive-$version-$buildNumber-macos-universal.zip';
 }
 
 class VersionController extends GetxController {
@@ -78,9 +88,14 @@ class VersionController extends GetxController {
     // Android
     // =====================================================
 
-    apkUrl.value = assets.androidArmeabiV7a;
-    apkUrl2.value = assets.androidArm64;
-    apkUrl3.value = assets.androidX8664;
+    final androidAbis = VersionUtil.latestAndroidAbis;
+    apkUrl.value = androidAbis.contains('armeabi-v7a')
+        ? assets.androidArmeabiV7a
+        : '';
+    apkUrl2.value = androidAbis.contains('arm64-v8a')
+        ? assets.androidArm64
+        : '';
+    apkUrl3.value = androidAbis.contains('x86_64') ? assets.androidX8664 : '';
 
     // =====================================================
     // Windows

--- a/test/release_asset_urls_test.dart
+++ b/test/release_asset_urls_test.dart
@@ -10,10 +10,41 @@ void main() {
       buildNumber: 52,
     );
 
-    expect(urls.androidArm64, endsWith('/PureLive-2.1.4-52-arm64-v8a-release.apk'));
-    expect(urls.windowsSetup, endsWith('/PureLive-2.1.4-windows-x64-setup.exe'));
-    expect(urls.windowsPortable, endsWith('/PureLive-2.1.4-52-windows-x64-portable.zip'));
-    expect(urls.macosUniversal, endsWith('/PureLive-2.1.4-52-macos-universal.zip'));
+    expect(
+      urls.androidArm64,
+      endsWith('/PureLive-2.1.4-52-arm64-v8a-release.apk'),
+    );
+    expect(
+      urls.androidArmeabiV7a,
+      endsWith('/PureLive-2.1.4-52-armeabi-v7a-release.apk'),
+    );
+    expect(
+      urls.androidX8664,
+      endsWith('/PureLive-2.1.4-52-x86_64-release.apk'),
+    );
+    expect(
+      urls.windowsSetup,
+      endsWith('/PureLive-2.1.4-windows-x64-setup.exe'),
+    );
+    expect(
+      urls.windowsPortable,
+      endsWith('/PureLive-2.1.4-52-windows-x64-portable.zip'),
+    );
+    expect(
+      urls.macosUniversal,
+      endsWith('/PureLive-2.1.4-52-macos-universal.zip'),
+    );
+  });
+
+  test('Android update links follow the APK variants declared by the feed', () {
+    expect(
+      VersionUtil.selectAndroidAbis({
+        'android_abis': ['armeabi-v7a', 'arm64-v8a', 'x86_64', 'unsupported'],
+      }),
+      {'armeabi-v7a', 'arm64-v8a', 'x86_64'},
+    );
+    expect(VersionUtil.selectAndroidAbis({}), {'arm64-v8a'});
+    expect(VersionUtil.selectAndroidAbis({'android_abis': []}), isEmpty);
   });
 
   test('platform update feed does not announce an unpublished artifact to other platforms', () {
@@ -25,7 +56,19 @@ void main() {
       },
     };
 
-    expect(VersionUtil.selectPlatformVersionData(feed, platform: 'windows')['version'], '2.1.2');
-    expect(VersionUtil.selectPlatformVersionData(feed, platform: 'android')['version'], '2.1.1');
+    expect(
+      VersionUtil.selectPlatformVersionData(
+        feed,
+        platform: 'windows',
+      )['version'],
+      '2.1.2',
+    );
+    expect(
+      VersionUtil.selectPlatformVersionData(
+        feed,
+        platform: 'android',
+      )['version'],
+      '2.1.1',
+    );
   });
 }


### PR DESCRIPTION
## 概要

这是 #747 合并后的通用后续修正，保持上游当前三 ABI 发布方式，同时让本机自托管构建和应用内下载入口更可靠。

- Windows 自托管 Android Runner 依次检测工具缓存、Android Studio JBR 与 `JAVA_HOME`，并校验实际 Java 主版本为 25；不再要求临时 Runner 必须预填专用 Tool Cache。
- `assets/version.json` 明确声明本次实际发布的 `armeabi-v7a`、`arm64-v8a` 与 `x86_64`。
- 更新页只为版本清单声明的 ABI 生成 APK 下载按钮；旧清单仍默认 arm64，显式空列表不会产生不存在的下载链接。
- 增加三 ABI URL 与版本清单筛选回归测试。

## 验证

- Flutter Analyze：0 issue
- `test/release_asset_urls_test.dart`：3/3 通过
- 工作流 YAML 与 `assets/version.json` 解析通过
- v2.1.4 Release 三个 APK 附件名称已与清单逐项核对