### PR TITLE
fix: synchronize local danmaku and smooth scrolling

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1087,6 +1087,7 @@
   "copy": "Copy",
   "save": "Save",
   "local_send_message": "Send local danmaku",
+  "local_message_queued": "Sent. It will appear everywhere in 2 seconds",
   "danmaku_new_messages": "{count} new messages - tap to resume",
   "block_danmaku_user": "Block this user's danmaku",
   "block_danmaku_keyword": "Block a danmaku keyword",

--- a/assets/translations/zh.json
+++ b/assets/translations/zh.json
@@ -1087,6 +1087,7 @@
   "copy": "复制",
   "save": "保存",
   "local_send_message": "发送本地弹幕",
+  "local_message_queued": "发送成功，将在 2 秒后同步显示",
   "danmaku_new_messages": "{count} 条新弹幕，点击回到底部",
   "block_danmaku_user": "屏蔽该用户的弹幕",
   "block_danmaku_keyword": "屏蔽弹幕关键词",

--- a/lib/common/base/base_page_scroll_bone.dart
+++ b/lib/common/base/base_page_scroll_bone.dart
@@ -4,7 +4,7 @@ import 'package:pure_live/common/index.dart';
 import 'package:pure_live/common/base/base_controller.dart';
 
 abstract class BasePageScrollAndStateBone<T> extends BaseController {
-  final ScrollController scrollController = ScrollController();
+  final ScrollController scrollController = createPureLiveScrollController();
   final EasyRefreshController easyRefreshController = EasyRefreshController(
     controlFinishRefresh: true,
     controlFinishLoad: true,

--- a/lib/common/widgets/index.dart
+++ b/lib/common/widgets/index.dart
@@ -7,3 +7,4 @@ export './menu_button.dart';
 export './search_button.dart';
 export './section_listtile.dart';
 export './pure_live_scroll_physics.dart';
+export './pure_live_scroll_controller.dart';

--- a/lib/common/widgets/pure_live_scroll_controller.dart
+++ b/lib/common/widgets/pure_live_scroll_controller.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:scroll_animator/scroll_animator.dart';
+
+/// Uses Chromium's Windows scrolling personality for discrete wheel deltas.
+/// Touch scrolling keeps Flutter's native position implementation.
+ScrollController createPureLiveScrollController({double initialScrollOffset = 0}) {
+  if (defaultTargetPlatform == TargetPlatform.windows) {
+    return AnimatedScrollController(
+      animationFactory: const ChromiumImpulse(),
+      initialScrollOffset: initialScrollOffset,
+    );
+  }
+  return ScrollController(initialScrollOffset: initialScrollOffset);
+}

--- a/lib/modules/live_play/controllers/live_play_controller.dart
+++ b/lib/modules/live_play/controllers/live_play_controller.dart
@@ -18,6 +18,7 @@ import 'package:pure_live/modules/live_play/states/live_play_state.dart';
 import 'package:pure_live/modules/live_play/controllers/player_state.dart';
 import 'package:pure_live/modules/live_play/widgets/danmaku_list_view.dart';
 import 'package:pure_live/modules/live_play/local_interaction_controller.dart';
+import 'package:pure_live/modules/live_play/local_message_delivery_queue.dart';
 import 'package:pure_live/recorder/pages/recorder/recorder_controller.dart';
 import 'package:pure_live/modules/live_play/controllers/timer_controller.dart';
 import 'package:pure_live/modules/live_play/controllers/player_controller.dart';
@@ -58,17 +59,20 @@ class LivePlayController extends GetxController with GetSingleTickerProviderStat
   Timer? _localGiftEffectTimer;
   Timer? _danmakuFlushTimer;
   final List<LiveMessage> _pendingDanmakuMessages = <LiveMessage>[];
+  late final LocalMessageDeliveryQueue _localMessageDeliveryQueue;
   late final String _controllerTag;
 
   static const int _maxDanmakuHistory = 500;
   static const int _maxPendingDanmakuBatch = 200;
   static const Duration _danmakuBatchWindow = Duration(milliseconds: 32);
+  static const Duration localChatDeliveryDelay = Duration(seconds: 2);
 
   @override
   void onInit() {
     super.onInit();
     _controllerTag = '${identityHashCode(this)}';
     currentSite = Sites.of(site);
+    _localMessageDeliveryQueue = LocalMessageDeliveryQueue(onDeliver: _deliverLocalMessage);
 
     final autoStartAsmr = Platform.isAndroid && SettingsService.to.app.enableAsmrSleepMode.v;
     _asmrSessionActive = autoStartAsmr;
@@ -187,12 +191,18 @@ class LivePlayController extends GetxController with GetSingleTickerProviderStat
     }
   }
 
-  void addDanmakuMessage(LiveMessage msg) {
+  void addDanmakuMessage(LiveMessage msg, {bool immediate = false}) {
     if (isClosed) return;
     if (_pendingDanmakuMessages.length >= _maxPendingDanmakuBatch) {
       _pendingDanmakuMessages.removeAt(0);
     }
     _pendingDanmakuMessages.add(msg);
+    if (immediate) {
+      _danmakuFlushTimer?.cancel();
+      _danmakuFlushTimer = null;
+      _flushDanmakuMessages();
+      return;
+    }
     _danmakuFlushTimer ??= Timer(_danmakuBatchWindow, _flushDanmakuMessages);
   }
 
@@ -246,12 +256,19 @@ class LivePlayController extends GetxController with GetSingleTickerProviderStat
     updateRoom(detail: candidate.withAudienceFallbackFrom(detail));
   }
 
-  void emitLocalMessage(LiveMessage msg, {required bool showAsDanmaku}) {
+  void emitLocalMessage(LiveMessage msg, {required bool showAsDanmaku, Duration delay = Duration.zero}) {
     if (!localInteractionController.enabled.v) return;
-    addDanmakuMessage(msg);
-    if (showAsDanmaku) {
-      state.value.player.videoController?.sendDanmaku(msg);
-    }
+    _localMessageDeliveryQueue.schedule(
+      LocalMessageDelivery(message: msg, showAsDanmaku: showAsDanmaku, roomEpoch: _roomLoadEpoch),
+      delay: delay,
+    );
+  }
+
+  void _deliverLocalMessage(LocalMessageDelivery delivery) {
+    if (isClosed || _ownerClosed || delivery.roomEpoch != _roomLoadEpoch) return;
+    final msg = delivery.message;
+    addDanmakuMessage(msg, immediate: true);
+    if (delivery.showAsDanmaku) state.value.player.videoController?.sendDanmaku(msg);
     if (msg.type == LiveMessageType.gift && localInteractionController.enableGiftEffects.v) {
       localGiftEffect.v = msg;
       _localGiftEffectTimer?.cancel();
@@ -462,6 +479,7 @@ class LivePlayController extends GetxController with GetSingleTickerProviderStat
     // Fence any room-detail/play-quality request that was started before this
     // switch. Its late result must not restore the previous room or socket.
     invalidateRoomLoad();
+    _localMessageDeliveryQueue.cancelAll();
     final sameRoom =
         state.value.room.detail?.roomId == newRoom.roomId && state.value.room.detail?.platform == newRoom.platform;
 
@@ -636,6 +654,7 @@ class LivePlayController extends GetxController with GetSingleTickerProviderStat
     _ownerClosed = true;
     _roomLoadEpoch++;
     _localGiftEffectTimer?.cancel();
+    _localMessageDeliveryQueue.dispose();
     _danmakuFlushTimer?.cancel();
     _pendingDanmakuMessages.clear();
     tabController.dispose();

--- a/lib/modules/live_play/danmaku_viewing_preset.dart
+++ b/lib/modules/live_play/danmaku_viewing_preset.dart
@@ -1,0 +1,99 @@
+class DanmakuViewingPreset {
+  const DanmakuViewingPreset({
+    required this.id,
+    required this.labelKey,
+    required this.area,
+    required this.top,
+    required this.bottom,
+    required this.speed,
+    required this.fontSize,
+    required this.fontBorder,
+    required this.opacity,
+    required this.stroke,
+  });
+
+  final String id;
+  final String labelKey;
+  final double area;
+  final double top;
+  final double bottom;
+  final double speed;
+  final double fontSize;
+  final double fontBorder;
+  final double opacity;
+  final bool stroke;
+
+  static const values = <DanmakuViewingPreset>[
+    DanmakuViewingPreset(
+      id: 'best',
+      labelKey: 'danmaku_template_best',
+      area: 0.20,
+      top: 0,
+      bottom: 0,
+      speed: 118,
+      fontSize: 16,
+      fontBorder: 1.5,
+      opacity: 0.92,
+      stroke: true,
+    ),
+    DanmakuViewingPreset(
+      id: 'comfort',
+      labelKey: 'danmaku_template_comfort',
+      area: 0.35,
+      top: 0,
+      bottom: 0,
+      speed: 105,
+      fontSize: 17,
+      fontBorder: 1.5,
+      opacity: 0.90,
+      stroke: true,
+    ),
+    DanmakuViewingPreset(
+      id: 'dense',
+      labelKey: 'danmaku_template_dense',
+      area: 0.55,
+      top: 0,
+      bottom: 0,
+      speed: 138,
+      fontSize: 15,
+      fontBorder: 1.2,
+      opacity: 0.88,
+      stroke: true,
+    ),
+    DanmakuViewingPreset(
+      id: 'default',
+      labelKey: 'reset',
+      area: 1,
+      top: 0,
+      bottom: 0,
+      speed: 120,
+      fontSize: 16,
+      fontBorder: 1.5,
+      opacity: 1,
+      stroke: true,
+    ),
+  ];
+
+  bool matches({
+    required double area,
+    required double top,
+    required double bottom,
+    required double speed,
+    required double fontSize,
+    required double fontBorder,
+    required double opacity,
+    required bool stroke,
+    required bool autoFps,
+  }) {
+    bool close(double left, double right) => (left - right).abs() < 0.001;
+    return autoFps &&
+        stroke == this.stroke &&
+        close(area, this.area) &&
+        close(top, this.top) &&
+        close(bottom, this.bottom) &&
+        close(speed, this.speed) &&
+        close(fontSize, this.fontSize) &&
+        close(fontBorder, this.fontBorder) &&
+        close(opacity, this.opacity);
+  }
+}

--- a/lib/modules/live_play/local_message_delivery_queue.dart
+++ b/lib/modules/live_play/local_message_delivery_queue.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:pure_live/common/models/live_message.dart';
+
+class LocalMessageDelivery {
+  const LocalMessageDelivery({required this.message, required this.showAsDanmaku, required this.roomEpoch});
+
+  final LiveMessage message;
+  final bool showAsDanmaku;
+  final int roomEpoch;
+}
+
+/// Keeps delayed local interactions ordered and makes cancellation explicit
+/// when the room changes or the owning controller is disposed.
+class LocalMessageDeliveryQueue {
+  LocalMessageDeliveryQueue({required this.onDeliver});
+
+  final void Function(LocalMessageDelivery delivery) onDeliver;
+  final Set<Timer> _timers = <Timer>{};
+  bool _disposed = false;
+
+  int get pendingCount => _timers.length;
+
+  void schedule(LocalMessageDelivery delivery, {required Duration delay}) {
+    if (_disposed) return;
+    late final Timer timer;
+    timer = Timer(delay, () {
+      _timers.remove(timer);
+      if (_disposed) return;
+      onDeliver(delivery);
+    });
+    _timers.add(timer);
+  }
+
+  void cancelAll() {
+    for (final timer in _timers) {
+      timer.cancel();
+    }
+    _timers.clear();
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    cancelAll();
+  }
+}

--- a/lib/modules/live_play/widgets/danmaku_list_view.dart
+++ b/lib/modules/live_play/widgets/danmaku_list_view.dart
@@ -10,6 +10,12 @@ import 'package:pure_live/modules/live_play/controllers/player_state.dart';
 import 'package:pure_live/modules/live_play/controllers/live_play_controller.dart';
 import 'package:pure_live/modules/live_play/widgets/danmaku_message_actions.dart';
 
+bool isDanmakuUserScrollStart(ScrollNotification notification) {
+  return (notification is ScrollStartNotification && notification.dragDetails != null) ||
+      (notification is ScrollUpdateNotification && notification.dragDetails != null) ||
+      (notification is UserScrollNotification && notification.direction != ScrollDirection.idle);
+}
+
 class DanmakuListView extends StatefulWidget {
   final LiveRoom room;
 
@@ -20,7 +26,7 @@ class DanmakuListView extends StatefulWidget {
 }
 
 class DanmakuListViewState extends State<DanmakuListView> {
-  final ScrollController _scrollController = ScrollController();
+  final ScrollController _scrollController = createPureLiveScrollController();
   final TextEditingController _composerController = TextEditingController();
 
   static const Duration throttleDuration = Duration(milliseconds: 80);
@@ -78,6 +84,15 @@ class DanmakuListViewState extends State<DanmakuListView> {
       if (addedCount > 0) {
         _pendingMessageCount.value = (_pendingMessageCount.value + addedCount).clamp(0, 9999);
       }
+      return;
+    }
+
+    if (nextTail?.isLocal == true && addedCount > 0) {
+      throttleTimer?.cancel();
+      throttleTimer = null;
+      _scheduledSnapshot = null;
+      setState(() => _visibleMessages = snapshot);
+      WidgetsBinding.instance.addPostFrameCallback((_) => forceScrollToBottom());
       return;
     }
 
@@ -139,12 +154,20 @@ class DanmakuListViewState extends State<DanmakuListView> {
   }
 
   void onScrollNotification(ScrollNotification notification) {
-    if (notification is! UserScrollNotification || !_scrollController.hasClients) return;
+    if (!_scrollController.hasClients) return;
     final position = _scrollController.position;
     final distanceToBottom = position.pixels - position.minScrollExtent;
-    if (notification.direction != ScrollDirection.idle && distanceToBottom > 24) {
+
+    // A UserScrollNotification is emitted before the first drag has produced a
+    // useful pixel distance. Waiting for a 24 px offset let the 80 ms live
+    // update jump the list back to the bottom, so Android users had to swipe
+    // repeatedly. Claim a real drag (or mouse wheel) immediately.
+    if (isDanmakuUserScrollStart(notification)) {
       _pauseAutoScroll();
-    } else if (notification.direction == ScrollDirection.idle && distanceToBottom <= 12 && !_autoScrollEnabled) {
+    } else if ((notification is ScrollEndNotification ||
+            (notification is UserScrollNotification && notification.direction == ScrollDirection.idle)) &&
+        distanceToBottom <= 12 &&
+        !_autoScrollEnabled) {
       _resumeAutoScroll();
     }
   }
@@ -156,8 +179,10 @@ class DanmakuListViewState extends State<DanmakuListView> {
     controller.emitLocalMessage(
       local.createChat(text, platform: controller.site),
       showAsDanmaku: local.showAsDanmaku.v,
+      delay: LivePlayController.localChatDeliveryDelay,
     );
     _composerController.clear();
+    ToastUtil.show(i18n('local_message_queued'));
   }
 
   @override
@@ -183,6 +208,7 @@ class DanmakuListViewState extends State<DanmakuListView> {
                       return false;
                     },
                     child: ListView.builder(
+                      key: const ValueKey('danmaku-message-list'),
                       addAutomaticKeepAlives: false,
                       addRepaintBoundaries: true,
                       controller: _scrollController,
@@ -201,6 +227,7 @@ class DanmakuListViewState extends State<DanmakuListView> {
                       right: 12,
                       bottom: 12,
                       child: FilledButton.icon(
+                        key: const ValueKey('danmaku-resume-live'),
                         style: FilledButton.styleFrom(
                           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                           backgroundColor: Get.theme.colorScheme.primary.withValues(alpha: 0.92),

--- a/lib/modules/live_play/widgets/danmaku_settings_page.dart
+++ b/lib/modules/live_play/widgets/danmaku_settings_page.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:pure_live/common/index.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 import 'package:pure_live/common/widgets/count_button.dart';
+import 'package:pure_live/modules/live_play/danmaku_viewing_preset.dart';
 import 'package:pure_live/modules/settings/pages/pip_danmaku_settings_page.dart';
 import 'package:pure_live/modules/live_play/widgets/video_player/video_controller.dart';
 
@@ -15,7 +16,21 @@ class DanmakuSettingsPage extends StatefulWidget {
 }
 
 class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
+  late final ScrollController _scrollController;
+
   VideoController get controller => widget.controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = createPureLiveScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +41,7 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
 
     return Scaffold(
       body: SingleChildScrollView(
+        controller: _scrollController,
         physics: const PureLiveScrollPhysics(),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Column(
@@ -33,51 +49,49 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
           children: [
             context.buildGroupTitle(i18n('danmaku_templates')),
             const SizedBox(height: 8),
-            context.buildModernCard([
-              Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        FilledButton.tonalIcon(
-                          onPressed: () => _applyPreset('best'),
-                          icon: const Icon(Icons.auto_awesome_rounded),
-                          label: Text(i18n('danmaku_template_best')),
-                        ),
-                        OutlinedButton(
-                          onPressed: () => _applyPreset('comfort'),
-                          child: Text(i18n('danmaku_template_comfort')),
-                        ),
-                        OutlinedButton(
-                          onPressed: () => _applyPreset('dense'),
-                          child: Text(i18n('danmaku_template_dense')),
-                        ),
-                        OutlinedButton.icon(
-                          onPressed: _saveTemplate,
-                          icon: const Icon(Icons.save_outlined),
-                          label: Text(i18n('save_current_template')),
-                        ),
-                        OutlinedButton.icon(
-                          onPressed: _restoreTemplate,
-                          icon: const Icon(Icons.restore_rounded),
-                          label: Text(i18n('restore_saved_template')),
-                        ),
-                        TextButton(onPressed: () => _applyPreset('default'), child: Text(i18n('reset'))),
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    Text(
-                      '${i18n('danmaku_best_preset_desc')}\n${i18n('danmaku_realtime_hint')}',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(height: 1.45),
-                    ),
-                  ],
+            Obx(() {
+              final activePreset = _matchingPreset();
+              return context.buildModernCard([
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final preset in DanmakuViewingPreset.values)
+                            ChoiceChip(
+                              key: ValueKey('danmaku-template-${preset.id}'),
+                              selected: activePreset?.id == preset.id,
+                              showCheckmark: true,
+                              avatar: preset.id == 'best' ? const Icon(Icons.auto_awesome_rounded, size: 18) : null,
+                              label: Text(i18n(preset.labelKey)),
+                              onSelected: (_) => _applyPreset(preset),
+                            ),
+                          OutlinedButton.icon(
+                            onPressed: _saveTemplate,
+                            icon: const Icon(Icons.save_outlined),
+                            label: Text(i18n('save_current_template')),
+                          ),
+                          OutlinedButton.icon(
+                            onPressed: _restoreTemplate,
+                            icon: const Icon(Icons.restore_rounded),
+                            label: Text(i18n('restore_saved_template')),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      Text(
+                        '${i18n('danmaku_best_preset_desc')}\n${i18n('danmaku_realtime_hint')}',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(height: 1.45),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ]),
+              ]);
+            }),
             const SizedBox(height: 20),
             context.buildGroupTitle(i18n("danmaku_area")),
             const SizedBox(height: 8),
@@ -248,22 +262,36 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
     );
   }
 
-  void _applyPreset(String preset) {
-    final values = switch (preset) {
-      'best' => const [0.20, 0.0, 0.0, 118.0, 16.0, 1.5, 0.92, 1.0],
-      'comfort' => const [0.35, 0.0, 0.0, 105.0, 17.0, 1.5, 0.9, 1.0],
-      'dense' => const [0.55, 0.0, 0.0, 138.0, 15.0, 1.2, 0.88, 1.0],
-      _ => const [1.0, 0.0, 0.0, 120.0, 16.0, 1.5, 1.0, 1.0],
-    };
-    controller.danmakuArea.v = values[0];
-    controller.danmakuTopArea.v = values[1];
-    controller.danmakuBottomArea.v = values[2];
-    controller.danmakuSpeed.v = values[3];
-    controller.danmakuFontSize.v = values[4];
-    controller.danmakuFontBorder.v = values[5];
-    controller.danmakuOpacity.v = values[6];
-    controller.enableDanmakuStroke.v = values[7] == 1;
+  DanmakuViewingPreset? _matchingPreset() {
+    for (final preset in DanmakuViewingPreset.values) {
+      if (preset.matches(
+        area: controller.danmakuArea.v,
+        top: controller.danmakuTopArea.v,
+        bottom: controller.danmakuBottomArea.v,
+        speed: controller.danmakuSpeed.v,
+        fontSize: controller.danmakuFontSize.v,
+        fontBorder: controller.danmakuFontBorder.v,
+        opacity: controller.danmakuOpacity.v,
+        stroke: controller.enableDanmakuStroke.v,
+        autoFps: SettingsService.to.danmaku.danmakuAutoFps.v,
+      )) {
+        return preset;
+      }
+    }
+    return null;
+  }
+
+  void _applyPreset(DanmakuViewingPreset preset) {
+    controller.danmakuArea.v = preset.area;
+    controller.danmakuTopArea.v = preset.top;
+    controller.danmakuBottomArea.v = preset.bottom;
+    controller.danmakuSpeed.v = preset.speed;
+    controller.danmakuFontSize.v = preset.fontSize;
+    controller.danmakuFontBorder.v = preset.fontBorder;
+    controller.danmakuOpacity.v = preset.opacity;
+    controller.enableDanmakuStroke.v = preset.stroke;
     SettingsService.to.danmaku.danmakuAutoFps.v = true;
+    setState(() {});
     ToastUtil.show(i18n('danmaku_template_applied'));
   }
 

--- a/lib/modules/live_play/widgets/video_player/video_controller.dart
+++ b/lib/modules/live_play/widgets/video_player/video_controller.dart
@@ -153,7 +153,10 @@ class DanmakuManager {
   }
 
   void sendDanmaku(LiveMessage msg, bool isPlaying, bool isCompactMode) {
-    if (!isPlaying) return;
+    // A locally composed message is a UI interaction rather than a packet from
+    // the live transport. Do not silently discard it while playback is still
+    // starting or briefly buffering.
+    if (!isPlaying && !msg.isLocal) return;
 
     final originalColor = Color.fromARGB(255, msg.color.r, msg.color.g, msg.color.b);
     final settings = settingsService.danmaku;
@@ -258,7 +261,7 @@ class VideoController with ChangeNotifier {
 
   // EPG相关
   final RxList<database.EpgProgramme> currentChannelSchedule = <database.EpgProgramme>[].obs;
-  final ScrollController scheduleScrollController = ScrollController();
+  final ScrollController scheduleScrollController = createPureLiveScrollController();
   late ListObserverController scheduleObserverController;
   bool hasScrolledToLive = false;
 

--- a/lib/modules/search/search_controller.dart
+++ b/lib/modules/search/search_controller.dart
@@ -16,7 +16,7 @@ class SearchController extends GetxController with GetSingleTickerProviderStateM
   final errorMessage = ''.obs;
   final includeOffline = true.obs;
   final sortMode = LiveSearchSortMode.smart.obs;
-  final ScrollController scrollController = ScrollController();
+  final ScrollController scrollController = createPureLiveScrollController();
   bool _isWebView2Available = true;
   int _searchGeneration = 0;
   int _settledTabIndex = 0;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1942,6 +1942,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  scroll_animator:
+    dependency: "direct main"
+    description:
+      name: scroll_animator
+      sha256: "6b8b0f03b7eb47cd014a8aecf69e1504257da3af2f4b408fe3cbba4513814e5c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   scroll_to_index:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -194,6 +194,7 @@ dependencies:
   back_button_interceptor: ^8.0.4 # 返回键拦截
   easy_localization: ^3.0.8 #多语言
   app_links: ^7.2.1
+  scroll_animator: 0.3.0
 # 依赖覆盖（强制指定版本）
 dependency_overrides:
   # 上游网页内核的 Android 子包仍引用 AGP 9 已移除的默认 ProGuard 文件；

--- a/test/danmaku_list_scroll_policy_test.dart
+++ b/test/danmaku_list_scroll_policy_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pure_live/modules/live_play/widgets/danmaku_list_view.dart';
+
+void main() {
+  final metrics = FixedScrollMetrics(
+    minScrollExtent: 0,
+    maxScrollExtent: 1000,
+    pixels: 0,
+    viewportDimension: 400,
+    axisDirection: AxisDirection.down,
+    devicePixelRatio: 1,
+  );
+
+  test('the first Android drag pauses live following before it moves', () {
+    final notification = ScrollStartNotification(
+      metrics: metrics,
+      context: null,
+      dragDetails: DragStartDetails(globalPosition: Offset.zero),
+    );
+    expect(isDanmakuUserScrollStart(notification), isTrue);
+  });
+
+  test('programmatic scroll start does not pause live following', () {
+    final notification = ScrollStartNotification(metrics: metrics, context: null);
+    expect(isDanmakuUserScrollStart(notification), isFalse);
+  });
+
+  testWidgets('mouse wheel user direction pauses live following immediately', (tester) async {
+    const targetKey = ValueKey('target');
+    await tester.pumpWidget(const MaterialApp(home: SizedBox(key: targetKey)));
+    final notification = UserScrollNotification(
+      metrics: metrics,
+      context: tester.element(find.byKey(targetKey)),
+      direction: ScrollDirection.forward,
+    );
+    expect(isDanmakuUserScrollStart(notification), isTrue);
+  });
+}

--- a/test/danmaku_viewing_preset_test.dart
+++ b/test/danmaku_viewing_preset_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pure_live/modules/live_play/danmaku_viewing_preset.dart';
+
+void main() {
+  test('each viewing preset only matches its actual rendered values', () {
+    for (final preset in DanmakuViewingPreset.values) {
+      expect(
+        preset.matches(
+          area: preset.area,
+          top: preset.top,
+          bottom: preset.bottom,
+          speed: preset.speed,
+          fontSize: preset.fontSize,
+          fontBorder: preset.fontBorder,
+          opacity: preset.opacity,
+          stroke: preset.stroke,
+          autoFps: true,
+        ),
+        isTrue,
+        reason: preset.id,
+      );
+      expect(
+        preset.matches(
+          area: preset.area + 0.01,
+          top: preset.top,
+          bottom: preset.bottom,
+          speed: preset.speed,
+          fontSize: preset.fontSize,
+          fontBorder: preset.fontBorder,
+          opacity: preset.opacity,
+          stroke: preset.stroke,
+          autoFps: true,
+        ),
+        isFalse,
+        reason: '${preset.id} must clear selection after manual edits',
+      );
+    }
+  });
+
+  test('preset selection clears when dynamic FPS is disabled', () {
+    final preset = DanmakuViewingPreset.values.first;
+    expect(
+      preset.matches(
+        area: preset.area,
+        top: preset.top,
+        bottom: preset.bottom,
+        speed: preset.speed,
+        fontSize: preset.fontSize,
+        fontBorder: preset.fontBorder,
+        opacity: preset.opacity,
+        stroke: preset.stroke,
+        autoFps: false,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/desktop_scroll_behavior_test.dart
+++ b/test/desktop_scroll_behavior_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/gestures.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pure_live/common/global/platform/desktop_manager.dart';
+import 'package:pure_live/common/widgets/pure_live_scroll_controller.dart';
+import 'package:scroll_animator/scroll_animator.dart';
 
 void main() {
   test('MyCustomScrollBehavior supports trackpad and mouse drag scrolling', () {
@@ -10,5 +13,23 @@ void main() {
     expect(behavior.dragDevices, contains(PointerDeviceKind.invertedStylus));
     expect(behavior.dragDevices, contains(PointerDeviceKind.mouse));
     expect(behavior.dragDevices, contains(PointerDeviceKind.touch));
+  });
+
+  test('Windows wheel scrolling uses an animated scroll position', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    final controller = createPureLiveScrollController();
+    addTearDown(controller.dispose);
+    expect(controller, isA<AnimatedScrollController>());
+  });
+
+  test('Android touch scrolling keeps the native scroll controller', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    final controller = createPureLiveScrollController();
+    addTearDown(controller.dispose);
+    expect(controller, isNot(isA<AnimatedScrollController>()));
   });
 }

--- a/test/local_message_delivery_queue_test.dart
+++ b/test/local_message_delivery_queue_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pure_live/common/models/live_message.dart';
+import 'package:pure_live/modules/live_play/local_message_delivery_queue.dart';
+
+void main() {
+  LiveMessage message(String text) => LiveMessage(
+    type: LiveMessageType.chat,
+    userName: 'local',
+    message: text,
+    color: LiveMessageColor.white,
+    isLocal: true,
+  );
+
+  test('delivers a local message once after its configured delay', () async {
+    final delivered = <LocalMessageDelivery>[];
+    final queue = LocalMessageDeliveryQueue(onDeliver: delivered.add);
+    queue.schedule(
+      LocalMessageDelivery(message: message('hello'), showAsDanmaku: true, roomEpoch: 3),
+      delay: const Duration(milliseconds: 20),
+    );
+
+    expect(delivered, isEmpty);
+    expect(queue.pendingCount, 1);
+    await Future<void>.delayed(const Duration(milliseconds: 35));
+    expect(delivered.single.message.message, 'hello');
+    expect(delivered.single.showAsDanmaku, isTrue);
+    expect(queue.pendingCount, 0);
+    queue.dispose();
+  });
+
+  test('cancels delayed messages when a room is replaced', () async {
+    final delivered = <LocalMessageDelivery>[];
+    final queue = LocalMessageDeliveryQueue(onDeliver: delivered.add);
+    queue.schedule(
+      LocalMessageDelivery(message: message('stale'), showAsDanmaku: true, roomEpoch: 1),
+      delay: const Duration(milliseconds: 20),
+    );
+    queue.cancelAll();
+
+    await Future<void>.delayed(const Duration(milliseconds: 35));
+    expect(delivered, isEmpty);
+    expect(queue.pendingCount, 0);
+    queue.dispose();
+  });
+}


### PR DESCRIPTION
## Summary

- queue locally composed danmaku for a 2-second delivery delay, then publish the same message to the list and video overlay; cancel pending deliveries when switching rooms
- pause portrait-list auto-follow on the first real touch drag or wheel event, while keeping programmatic scrolling from falsely pausing it
- derive the active danmaku preset from live settings so the selected chip always matches rendered values
- animate discrete Windows wheel deltas with Chromium's Windows scrolling personality on the main grids, search, danmaku list, schedule, and danmaku settings surfaces

## Root causes

- local messages were dropped by the overlay whenever playback was still starting/buffering, and list/overlay publication was split across separate paths
- the list waited for a 24 px offset even though the first user-scroll notification arrives before pixels move; the 80 ms live-follow update could jump back first
- preset buttons had no selection state connected to the reactive danmaku values
- ordinary Flutter `ScrollPhysics` does not animate Windows pointer-wheel deltas

## Validation

- Built-in Kotlin audit: passed (10 Gradle files)
- Flutter analyze: no issues
- Flutter test: 91/91 passed on the clean upstream branch
- public interface probes: 26/26 passed
- Android arm64 release and Windows x64 release compiled from the same change on the maintenance branch
