### PR TITLE
fix(huya): use matching tokens and HTTPS stream URLs

### DIFF
--- a/lib/core/site/huya_site.dart
+++ b/lib/core/site/huya_site.dart
@@ -179,13 +179,36 @@ class HuyaSite implements LiveSite {
   }
 
   Future<String> getPlayUrl(HuyaLineModel line, int bitRate) async {
-    var antiCode = await getCndTokenInfoEx(line.streamName);
-    antiCode = buildAntiCode(line.streamName, line.presenterUid, antiCode);
-    var url = '${line.line}/${line.streamName}.flv?$antiCode&codec=264';
-    if (bitRate > 0) {
-      url += "&ratio=$bitRate";
+    var antiCode = line.lineType == HuyaLineType.hls ? line.hlsAntiCode.trim() : line.flvAntiCode.trim();
+    if (antiCode.isEmpty && line.lineType == HuyaLineType.flv) {
+      antiCode = await getCndTokenInfoEx(line.streamName);
+      antiCode = buildAntiCode(line.streamName, line.presenterUid, antiCode);
+    }
+    if (antiCode.isEmpty) {
+      final protocol = line.lineType == HuyaLineType.hls ? 'HLS' : 'FLV';
+      throw StateError('Huya $protocol token is unavailable');
+    }
+
+    final extension = line.lineType == HuyaLineType.hls ? 'm3u8' : 'flv';
+    final cdnBase = secureHuyaCdnBase(line.line);
+    var url = '$cdnBase/${line.streamName}.$extension?$antiCode';
+    if (!RegExp(r'(^|&)codec=').hasMatch(antiCode)) {
+      url += '&codec=264';
+    }
+    if (bitRate > 0 && !RegExp(r'(^|&)ratio=').hasMatch(antiCode)) {
+      url += '&ratio=$bitRate';
     }
     return url;
+  }
+
+  static String secureHuyaCdnBase(String base) {
+    final uri = Uri.tryParse(base);
+    if (uri == null ||
+        uri.scheme != 'http' ||
+        !(uri.host == 'huya.com' || uri.host.endsWith('.huya.com'))) {
+      return base;
+    }
+    return uri.replace(scheme: 'https').toString();
   }
 
   @override

--- a/test/huya_play_url_test.dart
+++ b/test/huya_play_url_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pure_live/core/site/huya_site.dart';
+
+void main() {
+  HuyaLineModel line(
+    HuyaLineType type,
+    String base, {
+    String flvAntiCode = 'wsSecret=flv-token&wsTime=6a87f351',
+    String hlsAntiCode = 'wsSecret=hls-token&wsTime=6a87f351',
+  }) {
+    return HuyaLineModel(
+      line: base,
+      lineType: type,
+      flvAntiCode: flvAntiCode,
+      hlsAntiCode: hlsAntiCode,
+      streamName: 'stream-name',
+      cdnType: 'AL',
+      presenterUid: 123,
+    );
+  }
+
+  test('Huya FLV URL uses the FLV token and extension', () async {
+    final url = await HuyaSite().getPlayUrl(
+      line(HuyaLineType.flv, 'http://al.flv.huya.com/src'),
+      8000,
+    );
+
+    expect(url, startsWith('https://al.flv.huya.com/src/stream-name.flv?'));
+    expect(url, contains('wsSecret=flv-token'));
+    expect(url, isNot(contains('wsSecret=hls-token')));
+    expect(url, contains('&codec=264'));
+    expect(url, contains('&ratio=8000'));
+  });
+
+  test('Huya HLS URL uses the HLS token and extension', () async {
+    final url = await HuyaSite().getPlayUrl(
+      line(HuyaLineType.hls, 'http://al.hls.huya.com/src'),
+      2000,
+    );
+
+    expect(url, startsWith('https://al.hls.huya.com/src/stream-name.m3u8?'));
+    expect(url, contains('wsSecret=hls-token'));
+    expect(url, isNot(contains('wsSecret=flv-token')));
+    expect(url, contains('&codec=264'));
+    expect(url, contains('&ratio=2000'));
+  });
+
+  test('Huya CDN bases use HTTPS without rewriting unrelated hosts', () {
+    expect(
+      HuyaSite.secureHuyaCdnBase('http://tx.flv.huya.com/src'),
+      'https://tx.flv.huya.com/src',
+    );
+    expect(
+      HuyaSite.secureHuyaCdnBase('http://example.com/src'),
+      'http://example.com/src',
+    );
+  });
+
+  test('Huya room tokens do not duplicate codec or ratio parameters', () async {
+    final url = await HuyaSite().getPlayUrl(
+      line(
+        HuyaLineType.hls,
+        'https://al.hls.huya.com/src',
+        hlsAntiCode: 'wsSecret=hls-token&wsTime=6a87f351&codec=265&ratio=4000',
+      ),
+      2000,
+    );
+
+    expect(RegExp(r'(^|&)codec=').allMatches(Uri.parse(url).query).length, 1);
+    expect(RegExp(r'(^|&)ratio=').allMatches(Uri.parse(url).query).length, 1);
+    expect(url, contains('&codec=265'));
+    expect(url, contains('&ratio=4000'));
+  });
+}


### PR DESCRIPTION
## 背景

虎牙房间详情同时返回 FLV、HLS 线路，以及各自独立的 `sFlvAntiCode` 和 `sHlsAntiCode`。现有实现不区分线路类型，始终请求 FLV WUP token，并始终拼接 `.flv`，因此 HLS 线路会生成协议、扩展名和 token 不匹配的地址。部分虎牙 CDN 的 HTTP 地址还会在播放少量数据后断开，而同一地址使用 HTTPS 可稳定播放。

## 修改

- FLV 线路使用 `sFlvAntiCode` 和 `.flv`。
- HLS 线路使用 `sHlsAntiCode` 和 `.m3u8`，不会复用 FLV token。
- 仅将 `http://huya.com` 及 `http://*.huya.com` 的流基地址升级为 HTTPS；其他域名保持原样。
- 如果房间 token 已带 `codec` 或 `ratio`，不会重复追加同名参数。
- 保留现有线路列表和手动线路选择，不增加自动切换或线路屏蔽。
- FLV 房间 token 缺失时保留原有 WUP token 作为同协议兜底；HLS 缺少 HLS token 时明确失败，不错误复用 FLV token。

## 验证

- `flutter test --no-pub test/huya_play_url_test.dart`：4 个测试通过。
- `flutter analyze --no-pub --no-fatal-infos --no-fatal-warnings lib/core/site/huya_site.dart test/huya_play_url_test.dart`：无问题。
- macOS 上使用等价 URL 生成逻辑手工检查虎牙 DANK1NG 直播间：协议/token 修复与 HTTPS 升级后可稳定播放。

测试环境：macOS，Flutter 3.47.0。

## 范围

- 无 UI 变化，不需要截图。
- 未包含双流、弹幕重连、播放器池或其他本地功能补丁。
