### PR TITLE
fix(macos): avoid CFBundle OpenGL lookup crash

### DIFF
--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -1,12 +1,29 @@
 import Cocoa
 import FlutterMacOS
 import XCTest
+@testable import media_kit_video
 
 class RunnerTests: XCTestCase {
 
   func testExample() {
     // If you add code to the Runner application, consider adding tests here.
     // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  }
+
+  func testOpenGLSymbolLoaderLoadsRequiredFunctions() {
+    for symbol in ["glGetString", "glBindFramebuffer", "glFlush"] {
+      symbol.withCString {
+        XCTAssertNotNil(OpenGLSymbolLoader.load($0), symbol)
+      }
+    }
+  }
+
+  func testOpenGLSymbolLoaderRejectsMissingNames() {
+    XCTAssertNil(OpenGLSymbolLoader.load(nil))
+
+    "pure_live_missing_opengl_symbol".withCString {
+      XCTAssertNil(OpenGLSymbolLoader.load($0))
+    }
   }
 
 }

--- a/third_party/media_kit_video/macos/media_kit_video/Sources/media_kit_video/plugin/OpenGLSymbolLoader.swift
+++ b/third_party/media_kit_video/macos/media_kit_video/Sources/media_kit_video/plugin/OpenGLSymbolLoader.swift
@@ -1,0 +1,23 @@
+import Darwin
+
+enum OpenGLSymbolLoader {
+  private static let frameworkPath =
+    "/System/Library/Frameworks/OpenGL.framework/OpenGL"
+
+  // Keep the framework loaded for the lifetime of the process. mpv may invoke
+  // the callback from its render worker at any point while the context exists.
+  private static let frameworkHandle = dlopen(
+    frameworkPath,
+    RTLD_LAZY | RTLD_LOCAL
+  )
+
+  static func load(
+    _ name: UnsafePointer<CChar>?
+  ) -> UnsafeMutableRawPointer? {
+    guard let frameworkHandle, let name else {
+      return nil
+    }
+
+    return dlsym(frameworkHandle, name)
+  }
+}

--- a/third_party/media_kit_video/macos/media_kit_video/Sources/media_kit_video/plugin/TextureHW.swift
+++ b/third_party/media_kit_video/macos/media_kit_video/Sources/media_kit_video/plugin/TextureHW.swift
@@ -194,18 +194,11 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
     _ ctx: UnsafeMutableRawPointer?,
     _ name: UnsafePointer<Int8>?
   ) -> UnsafeMutableRawPointer? {
-    let symbol: CFString = CFStringCreateWithCString(
-      kCFAllocatorDefault,
-      name,
-      kCFStringEncodingASCII
-    )
-    let indentifier = CFBundleGetBundleWithIdentifier(
-      "com.apple.opengl" as CFString
-    )
-    let addr = CFBundleGetFunctionPointerForName(indentifier, symbol)
+    let addr = OpenGLSymbolLoader.load(name)
 
     if addr == nil {
-      NSLog("Cannot get OpenGL function pointer!")
+      let symbol = name.map { String(cString: $0) } ?? "<nil>"
+      NSLog("Cannot get OpenGL function pointer: \(symbol)")
     }
     return addr
   }


### PR DESCRIPTION
## Motivation

Fixes #839.

Pure Live `3.0.10+4098` crashes reproducibly on macOS 26.5 Apple Silicon while MediaKit creates the mpv OpenGL render context. Three consecutive crash reports end in the same path:

```text
_CFBundleGetBundleWithIdentifier
TextureHW.getProcAddress(_:_:)
mpgl_load_functions2
mpv_render_context_create
TextureHW.initMPV()
```

## Provenance and root cause

- Classification: `external-drift` on a vendored `media_kit_video` implementation.
- Frozen maintenance-fork base: `7e0a51d8d104a38e7caae629d7a8bd4718423b74`.
- Frozen original-project head: `e226afe20c7a174311d9ee6aa2ea5c66fa212810` (the repositories currently have no merge base and the original-project tree does not contain this vendored file).
- The affected file entered this fork in `f3121c5b74c3a570d45b54e2df0ee72a1cb951ad` from the existing MediaKit implementation; MediaKit main still contains the same lookup.
- First invalid state: mpv asks `TextureHW.getProcAddress` for an OpenGL symbol, and the callback calls `CFBundleGetBundleWithIdentifier("com.apple.opengl")`. On macOS 26.5, CoreFoundation crashes while deriving a framework URL during that bundle lookup, before a render texture or stream is initialized.

This is independent of the stream URL, codec and danmaku lifecycle. Disabling GPU decode selects `TextureSW` and avoids the failing callback.

## Change

- Load `/System/Library/Frameworks/OpenGL.framework/OpenGL` once with `dlopen`.
- Keep that handle for process lifetime because mpv may request symbols while its render context exists.
- Resolve callback requests with `dlsym`, avoiding repeated CoreFoundation bundle enumeration.
- Return `nil` safely for a missing name, failed framework load or missing symbol.
- Add macOS runner tests for required OpenGL symbols and failure cases.

No settings, persisted data or non-macOS player path changes. Software rendering remains unchanged. Reverting this commit restores the previous loader; there is no migration.

## Verification

Passed on macOS 26.5 arm64:

```text
swiftc -warnings-as-errors -typecheck OpenGLSymbolLoader.swift
swiftc -warnings-as-errors -parse-as-library OpenGLSymbolLoader.swift open_gl_symbol_loader_smoke.swift -o open_gl_symbol_loader_smoke
./open_gl_symbol_loader_smoke
git diff origin/master...HEAD --check
```

The executable smoke test verifies that `glGetString`, `glBindFramebuffer` and `glFlush` resolve, while a nil name and a nonexistent symbol return nil.

## Evidence gaps / residual risk

- Full Flutter/macOS application build and `RunnerTests` were not run because this Mac currently has Command Line Tools but not full Xcode or the repository Flutter SDK.
- The reported Apple Silicon machine supplied the crash evidence and standalone loader execution, but the patched full app has not yet been sampled interactively.
- Intel and older macOS versions were not sampled. The framework path is the long-standing system OpenGL location supported by the project's existing deployment range.
- Linux, Windows, Android and iOS are unaffected because only the macOS plugin implementation changes.

